### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# MacOS system files
+**.DS_Store


### PR DESCRIPTION
Added exclusions for .DS_Store files in all project directories. These files are added by the MacOS file system, and are unnecessary as far as the project is concerned.