### PR TITLE
Changed when AndroidBuild action runs

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -20,7 +20,7 @@ jobs:
           
           echo "========== check paths of modified files =========="
           git diff --name-only HEAD^ HEAD &gt; files.txt
-          while IFS= read -r file
+          while (IFS= read -r file)
           do
             echo $file
             if [[ $file != Android/* ]]; then

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on : windows-latest
+    runs-on : ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -20,7 +20,7 @@ jobs:
           
           echo "========== check paths of modified files =========="
           git diff --name-only HEAD^ HEAD &gt; files.txt
-          while (IFS= read -r file)
+          while IFS= read -r file
           do
             echo $file
             if [[ $file != Android/* ]]; then

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -3,7 +3,6 @@ name: AndroidBuild
 on:
   pull_request :
     branches : [ main ]
-    paths : ['Android/**']
 
 jobs:
   build:
@@ -12,6 +11,26 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.0
+
+      - name: check if Android app files are changed
+        id: check_files
+        run: |
+          echo "=============== list modified files ==============="
+          git diff --name-only HEAD^ HEAD
+          
+          echo "========== check paths of modified files =========="
+          git diff --name-only HEAD^ HEAD &gt; files.txt
+          while IFS= read -r file
+          do
+            echo $file
+            if [[ $file != Android/* ]]; then
+              echo "This modified file is not under the 'db' folder."
+              echo "::set-output name=run_job::false"
+              break
+            else
+              echo "::set-output name=run_job::true"
+            fi
+          done &lt; files.txt
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3.13.0

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -3,6 +3,7 @@ name: AndroidBuild
 on:
   pull_request :
     branches : [ main ]
+    paths : ['Android/**']
 
 jobs:
   build:


### PR DESCRIPTION
Altered the GitHub action file (that builds the Android app) to alter the behaviour of the action.

Previously, the GitHub action that builds the Android app would run on all pull requests into main, regardless of whether the code being pushed requires a rebuild or not.

Following this change, only changes to files in the "Android/" directory will result in a rebuild taking place, and the check _should_ still pass when changes are made in other directories. (The action runs as a necessary check of the 'main' branch protection rule, and thus needs to pass in every successful pull request into 'main').