### PR TITLE
Create ssh-cloud_build.yml

### DIFF
--- a/.github/workflows/ssh-cloud_build.yml
+++ b/.github/workflows/ssh-cloud_build.yml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - working-directory: ./SSH-Cloud
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/ssh-cloud_build.yml
+++ b/.github/workflows/ssh-cloud_build.yml
@@ -28,7 +28,6 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
         
     - name: Build with Maven
       working-directory: ./SSH-Cloud

--- a/.github/workflows/ssh-cloud_build.yml
+++ b/.github/workflows/ssh-cloud_build.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Java CI with Maven
+name: SSH CI Workflow
 
 on:
   push:
@@ -28,7 +28,7 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: mave
+        cache: maven
         
     - name: Build with Maven
       working-directory: ./SSH-Cloud

--- a/.github/workflows/ssh-cloud_build.yml
+++ b/.github/workflows/ssh-cloud_build.yml
@@ -29,6 +29,7 @@ jobs:
         cache: maven
         
     - name: Build with Maven
+      working-directory: ./SSH-Cloud
       run: mvn -B package --file pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive

--- a/.github/workflows/ssh-cloud_build.yml
+++ b/.github/workflows/ssh-cloud_build.yml
@@ -1,0 +1,36 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+        
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/ssh-cloud_build.yml
+++ b/.github/workflows/ssh-cloud_build.yml
@@ -20,8 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Change working directory
+      run: cd ./SSH-Cloud
+    
     - uses: actions/checkout@v4
-    - working-directory: ./SSH-Cloud
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/ssh-cloud_build.yml
+++ b/.github/workflows/ssh-cloud_build.yml
@@ -20,16 +20,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Change working directory
-      run: cd ./SSH-Cloud
-    
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4.1.0
+
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
+        cache: mave
         
     - name: Build with Maven
       working-directory: ./SSH-Cloud

--- a/.github/workflows/ssh-cloud_build.yml
+++ b/.github/workflows/ssh-cloud_build.yml
@@ -30,7 +30,7 @@ jobs:
         distribution: 'temurin'
         
     - name: Build with Maven
-      working-directory: ./SSH-Cloud
+      working-directory: SSH-Cloud
       run: mvn -B package --file pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive


### PR DESCRIPTION
Created the initial build file for the SSH Cloud application.

The goal of this build file is to check whether the tests within the SSH Cloud project pass, and then if they do, create and upload a built .jar file.

**Note**: This is only the initial file, and it _will_ need further refinement. However, due to the nature of GitHub Actions workflows, we cannot test whether the action works when attempting to pull a branch into main without the Action workflow already being present on the main branch.